### PR TITLE
Events endpoint cursor-based pagination update

### DIFF
--- a/opensea/opensea.py
+++ b/opensea/opensea.py
@@ -5,12 +5,14 @@ from opensea import utils
 
 class OpenseaBase:
 
-    def __init__(self, endpoint, version="v1", base_url="https://api.opensea.io/api"):
+    def __init__(self, endpoint, version="v1",
+                 base_url="https://api.opensea.io/api"):
         """Base class to interact with the OpenSea API and fetch NFT data.
 
         Args:
             endpoint (str): OpenSea API endpoint, eg. 'asset' or 'collections'
-            version (str, optional): API version. Defaults to "v1".
+            version (str, optional): API version. Defaults to "v1"
+            base
         """
         self.api_url = f"{base_url}/{version}/{endpoint}"
 

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -10,7 +10,8 @@ class OpenseaAPI:
     MAX_COLLECTION_ITEMS = 300
     MAX_BUNDLE_ITEMS = 50
 
-    def __init__(self, base_url="https://api.opensea.io/api", apikey=None, version="v1"):
+    def __init__(self, base_url="https://api.opensea.io/api", apikey=None,
+                 version="v1"):
         """Base class to interact with the OpenSea API and fetch NFT data.
 
         Args:

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -15,6 +15,7 @@ class OpenseaAPI:
         """Base class to interact with the OpenSea API and fetch NFT data.
 
         Args:
+            base_url (str): OpenSea API base URL. Defaults to "https://api.opensea.io/api".
             apikey (str): OpenSea API key (you need to request one)
             version (str, optional): API version. Defaults to "v1".
         """
@@ -55,11 +56,13 @@ class OpenseaAPI:
         response = requests.get(url, headers=headers, params=params)
         if response.status_code == 400:
             raise ValueError(response.text)
+        elif response.status_code == 401:
+            raise requests.exceptions.HTTPError(response.text)
         elif response.status_code == 403:
             raise ConnectionError("The server blocked access.")
         elif response.status_code == 504:
             raise TimeoutError("The server reported a gateway time-out error.")
-
+        
         if export_file_name != "":
             utils.export_file(response.content, export_file_name)
         if return_response:

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -115,6 +115,7 @@ class OpenseaAPI:
         }
         if occurred_before is not None:
             query_params["occurred_before"] = occurred_before.timestamp()
+        return self._make_request("events", query_params, export_file_name)
 
     def asset(
         self,

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -78,10 +78,8 @@ class OpenseaAPI:
         event_type=None,
         only_opensea=False,
         auction_type=None,
-        offset=0,
         limit=None,
         occurred_before=None,
-        occurred_after=None,
         export_file_name="",
     ):
         """Fetches Events data from the API. Function arguments will be passed
@@ -101,10 +99,6 @@ class OpenseaAPI:
         Returns:
             [dict]: Events data
         """
-        if occurred_after is not None and not isinstance(occurred_after,
-                                                         datetime):
-            raise ValueError("occurred_after must be a datetime object")
-
         if occurred_before is not None and not isinstance(occurred_before,
                                                           datetime):
             raise ValueError("occurred_before must be a datetime object")
@@ -117,14 +111,10 @@ class OpenseaAPI:
             "event_type": event_type,
             "only_opensea": only_opensea,
             "auction_type": auction_type,
-            "offset": offset,
             "limit": self.MAX_EVENT_ITEMS if limit is None else limit,
         }
         if occurred_before is not None:
             query_params["occurred_before"] = occurred_before.timestamp()
-        if occurred_after is not None:
-            query_params["occurred_after"] = occurred_after.timestamp()
-        return self._make_request("events", query_params, export_file_name)
 
     def asset(
         self,

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -15,7 +15,8 @@ class OpenseaAPI:
         """Base class to interact with the OpenSea API and fetch NFT data.
 
         Args:
-            base_url (str): OpenSea API base URL. Defaults to "https://api.opensea.io/api".
+            base_url (str): OpenSea API base URL. Defaults to
+            "https://api.opensea.io/api".
             apikey (str): OpenSea API key (you need to request one)
             version (str, optional): API version. Defaults to "v1".
         """
@@ -62,7 +63,7 @@ class OpenseaAPI:
             raise ConnectionError("The server blocked access.")
         elif response.status_code == 504:
             raise TimeoutError("The server reported a gateway time-out error.")
-        
+
         if export_file_name != "":
             utils.export_file(response.content, export_file_name)
         if return_response:

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ deps = -r {toxinidir}/requirements_dev.txt
 commands =
     pip install -U pip
     pytest --basetemp={envtmpdir}
-
+    pytest {posargs}


### PR DESCRIPTION
This PR contains the changes needed to accommodate the new pagination of the /events endpoint (as described in the [OpenSea blog](https://opensea.io/blog/developers/wyvern-2-3-developer-upgrade-guide/))

This means that the `offset` and `occured_after` parameters are removed because they will stop working soon. (`occurred_before` will stay)

In the new pagination method, the API returns a `next` key with a URL that will lead you to the "next page" of events data.