### PR TITLE
0.1.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## 0.1.5 (2021-02-17)
+
+* Support for cursor-based pagination for /events endpoint
+* New function to help paginate the /events endpoint
+* Introducing a temporary function to fix the `next` url problem until OpenSea addresses this issue
+* Minor docs updates and cleanup
+
+
 ## 0.1.3 (2021-12-03)
 
 * Ability to reach all endpoints from one `OpenseaAPI` object

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,8 @@
 
 ## 0.1.5 (2021-02-17)
 
-* Support for cursor-based pagination for /events endpoint
+* Ability to override base_url with any other URL
+* Support for cursor-based pagination for /events endpoint (and removed deprecated arguments)
 * New function to help paginate the /events endpoint
 * Introducing a temporary function to fix the `next` url problem until OpenSea addresses this issue
 * Minor docs updates and cleanup

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This an API wrapper library for the [OpenSea API](https://docs.opensea.io/refere
 The library provides a simplified interface to fetch a diverse set of NFT data points from OpenSea. 
 
 ## Supported endpoints
-The wrapper covers **all** of the OpenSea API endpoints (as of 2021-12-02, NOT including the Orderbook and Rinkeby API):
+The wrapper covers the following OpenSea API endpoints:
 
 * [Single asset](#get-data-about-a-single-asset) ([/asset](https://docs.opensea.io/reference/retrieving-a-single-asset))
 * [Single asset contract](#get-data-about-a-single-asset-contract) ([/asset_contract](https://docs.opensea.io/reference/retrieving-a-single-contract))
@@ -17,7 +17,7 @@ The wrapper covers **all** of the OpenSea API endpoints (as of 2021-12-02, NOT i
 
 
 ## Prerequisite
-As of Dec 2, 2021 you need to have an **API key** to use the OpenSea API, and thus 
+You need to have an **API key** to use the OpenSea API, and thus
 you need one to use this wrapper too. [You can request a key here.](https://docs.opensea.io/reference/request-an-api-key) <br><br>
 NOTE: The API key can take over 4-7 days to be delivered. It also requires you to show the project you are working on. 
 
@@ -26,6 +26,11 @@ Install with pip:
 ```bash
 virtualenv env && source env/bin/activate
 pip install opensea-api
+```
+
+### Upgrade
+```bash
+pip install opensea-api -U
 ```
 
 ## Usage examples
@@ -60,10 +65,8 @@ result = api.collection_stats(collection_slug="cryptopunks")
 # fetch multiple events
 from opensea import utils as opensea_utils
 
-period_start = opensea_utils.datetime_utc(2021, 11, 6, 14, 25)
 period_end = opensea_utils.datetime_utc(2021, 11, 6, 14, 30)
 result = api.events(
-    occurred_after=period_start,
     occurred_before=period_end,
     limit=10,
     export_file_name="events.json",

--- a/opensea/__init__.py
+++ b/opensea/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Attila Toth"""
 __email__ = "hello@attilatoth.dev"
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 __all__ = ["Events", "Asset", "Assets", "Contract", "Collection",
            "CollectionStats", "Collections", "Bundles", "utils",
            "OpenseaAPI"]

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -24,13 +24,13 @@ class OpenseaAPI:
         self.apikey = apikey
 
     def _make_request(
-        self, endpoint, params=None, export_file_name="", return_response=False
-    ):
+        self, endpoint=None, params=None, export_file_name="",
+        return_response=False, next_url=None):
         """Makes a request to the OpenSea API and returns either a response
         object or dictionary.
 
         Args:
-            endpoint (str): API endpoint to use for the request.
+            endpoint (str, optional): API endpoint to use for the request.
             params (dict, optional): Query parameters to include in the
             request. Defaults to None.
             export_file_name (str, optional): In case you want to download the
@@ -40,20 +40,28 @@ class OpenseaAPI:
             return_response (bool, optional): Set it True if you want it to
             return the actual response object.
             By default, it's False, which means a dictionary will be returned.
+            next_url (str, optional): If you want to paginate, provide the
+            `next` value here (this is a URL) OpenSea provides in the response.
+            If this argument is provided, `endpoint` will be ignored.
 
         Raises:
             ValueError: returns the error message from the API in case one
             (or more) of your request parameters are incorrect.
+            HTTPError: Unauthorized access. Try using an API key.
             ConnectionError: your request got blocked by the server (try
             using an API key if you keep getting this error)
             TimeoutError: your request timed out (try rate limiting)
 
         Returns:
             Data sent back from the API. Either a response or dict object
-            depending on the *return_response* argument.
+            depending on the `return_response` argument.
         """
+        if endpoint is None and next_url is None:
+            raise ValueError("""You need to define either `endpoint` or
+                             `next_url` as an argument!""")
+
         headers = {"X-API-KEY": self.apikey}
-        url = f"{self.api_url}/{endpoint}"
+        url = next_url if endpoint is None else f"{self.api_url}/{endpoint}"
         response = requests.get(url, headers=headers, params=params)
         if response.status_code == 400:
             raise ValueError(response.text)

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -1,3 +1,4 @@
+import time
 import requests
 from datetime import datetime
 from opensea import utils
@@ -125,6 +126,47 @@ class OpenseaAPI:
         if occurred_before is not None:
             query_params["occurred_before"] = occurred_before.timestamp()
         return self._make_request("events", query_params, export_file_name)
+
+    def events_backfill(self, until, next_url, export_file_name="",
+                        rate_limiting=2):
+        """Download events and paginate over multiple pages until the given
+        time is reached. You need to make a regular `/events` request first to
+        use this function - to get the `next` value. The function returns a
+        generator.
+
+        Args:
+            until (datetime): How much data do you want?
+            How much do you want to go back in time? This datetime value will
+            provide that threshold.
+            next_url (str): This is the `next` value provided in the response
+            object returned by the API. (Meaning, you need to make a regular
+            `/events` request first to have this value)
+            export_file_name (str, optional): Exports the JSON data into a the
+            specified file.
+            rate_limiting (int, optional): Seconds to wait between requests.
+            Defaults to 2.
+
+        Yields:
+            dictionary: event data
+        """
+        if not isinstance(until, datetime):
+            raise ValueError("`until` must be a datetime object")
+        while True:
+            time.sleep(rate_limiting)
+            data = self._make_request(next_url=next_url,
+                                      export_file_name=export_file_name)
+
+            # temporary url fix
+            # normally you would use `next_url = data["next"]`
+            next_url = utils.next_url_fix(data["next"])
+
+            time_field = data["asset_events"][0]["created_date"]
+            current_time = utils.str_to_datetime_utc(time_field)
+            if current_time >= until:
+                yield data
+            else:
+                break
+        yield None
 
     def asset(
         self,

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -131,9 +131,9 @@ class OpenseaAPI:
                         rate_limiting=2):
         """
         EXPERIMENTAL FUNCTION!
-        
+
         Expected behaviour:
-        
+
         Download events and paginate over multiple pages until the given
         time is reached. You need to make a regular `/events` request first to
         use this function - to get the `next` value. The function returns a

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -129,7 +129,12 @@ class OpenseaAPI:
 
     def events_backfill(self, until, next_url, export_file_name="",
                         rate_limiting=2):
-        """Download events and paginate over multiple pages until the given
+        """
+        EXPERIMENTAL FUNCTION!
+        
+        Expected behaviour:
+        
+        Download events and paginate over multiple pages until the given
         time is reached. You need to make a regular `/events` request first to
         use this function - to get the `next` value. The function returns a
         generator.

--- a/opensea/utils.py
+++ b/opensea/utils.py
@@ -42,9 +42,9 @@ def datetime_utc(year, month, day, hour, minute):
 
 
 def next_url_fix(next_url):
-    """A temporary solution to make cursor-based pagination work 
+    """A temporary solution to make cursor-based pagination work
     with next URLs. This can ignored after OpenSea fixes the next URL.
-    As of 2022-02-17 the cursor-based pagination does not work 
+    As of 2022-02-17 the cursor-based pagination does not work
     without fixing the URL first.
 
     Args:

--- a/opensea/utils.py
+++ b/opensea/utils.py
@@ -39,3 +39,18 @@ def datetime_utc(year, month, day, hour, minute):
         datetime
     """
     return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+def next_url_fix(next_url):
+    """A temporary solution to make cursor-based pagination work 
+    with next URLs. This can ignored after OpenSea fixes the next URL.
+    As of 2022-02-17 the cursor-based pagination does not work 
+    without fixing the URL first.
+
+    Args:
+        url_not_working (str): the `next` value from the OpenSea response
+    Returns:
+        url (str): next URL that uses the *old* base url
+    """
+    working_url = "http://api.opensea.io/api/v1/"
+    return working_url + next_url.split('/v1/')[-1]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
         'Documentation': 'https://opensea-api.attilatoth.dev',
         'Source': 'https://github.com/zseta/python-opensea'
     },
-    version='0.1.4',
+    version='0.1.5',
     zip_safe=False,
 )


### PR DESCRIPTION
* Ability to override base_url with any other URL
* Support for cursor-based pagination for /events endpoint (and removed deprecated arguments)
* New function to help paginate the /events endpoint
* Introducing a temporary function to fix the `next` url problem until OpenSea addresses this issue
* Minor docs updates and cleanup