### PR TITLE
0.1.7

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 0.1.7 (2022-03-26)
+* Add support for [asset listings](https://docs.opensea.io/reference/asset-listings)
+    and [asset offers](https://docs.opensea.io/reference/asset-offers) endpoints
+* Add `occured_after` and `collection_editor` arguments to events endpoint
+* Handle SSL error when making requests
+* Docs: add example to paginate the events endpoint (using `events_backfill()`)
+
 ## 0.1.6 (2022-02-25)
 * Fix /events endpoint pagination (`events_backfill()` function) by
 passing only *the cursor hash* and not the full URL to the next request.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ The library provides a simplified interface to fetch a diverse set of NFT data p
 ## Supported endpoints
 The wrapper covers the following OpenSea API endpoints:
 
-* [Single asset](#get-data-about-a-single-asset) ([/asset](https://docs.opensea.io/reference/retrieving-a-single-asset))
-* [Single asset contract](#get-data-about-a-single-asset-contract) ([/asset_contract](https://docs.opensea.io/reference/retrieving-a-single-contract))
-* [Single collection](#get-data-about-a-single-collection) ([/collection](https://docs.opensea.io/reference/retrieving-a-single-collection))
-* [Collection stats](#get-collection-stats) ([/collection/{slug}/stats](https://docs.opensea.io/reference/retrieving-collection-stats))
-* [Multiple assets](#get-data-about-multiple-assets) ([/assets](https://docs.opensea.io/reference/getting-assets))
-* [Multiple collections](#get-data-about-multiple-collections) ([/collections](https://docs.opensea.io/reference/retrieving-collections))
-* [Multiple events](#get-data-about-multiple-events) ([/events](https://docs.opensea.io/reference/retrieving-asset-events))
-* [Multiple bundles](#get-data-about-multiple-bundles) ([/bundles](https://docs.opensea.io/reference/retrieving-bundles))
+* Single asset ([/asset](https://docs.opensea.io/reference/retrieving-a-single-asset))
+* Single asset contract ([/asset_contract](https://docs.opensea.io/reference/retrieving-a-single-contract))
+* Single collection ([/collection](https://docs.opensea.io/reference/retrieving-a-single-collection))
+* Collection stats ([/collection/{slug}/stats](https://docs.opensea.io/reference/retrieving-collection-stats))
+* Multiple assets] ([/assets](https://docs.opensea.io/reference/getting-assets))
+* Multiple collections ([/collections](https://docs.opensea.io/reference/retrieving-collections))
+* Multiple events ([/events](https://docs.opensea.io/reference/retrieving-asset-events))
+* Multiple bundles ([/bundles](https://docs.opensea.io/reference/retrieving-bundles))
 
 
 ## Prerequisite
@@ -74,11 +74,24 @@ result = api.events(
 
 # fetch multiple bundles
 result = api.bundles(limit=2)
+
+# paginate the events endpoint (cursors are handled internally)
+from datetime import datetime, timezone
+
+start_at = datetime(2021, 10, 5, 3, 25, tzinfo=timezone.utc)
+finish_at = datetime(2021, 10, 5, 3, 20, tzinfo=timezone.utc)
+
+event_generator = api.events_backfill(start=start_from,
+                                      until=finish_at,
+                                      event_type="successful")
+for event in event_generator:
+    if event is not None:
+        print(event) # or do other things with the event data
 ```
 
 [Here's a demo video showcasing the basics.](https://www.youtube.com/watch?v=ga4hTqNRjfw)
 
 ## Documentation
-* [Wrapper documentation](https://opensea-api.attilatoth.dev) (work in progress)
+* [Wrapper documentation](https://opensea-api.attilatoth.dev)
 * [OpenSea API documentation](https://docs.opensea.io/reference/api-overview)
 

--- a/opensea/__init__.py
+++ b/opensea/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Attila Toth"""
 __email__ = "hello@attilatoth.dev"
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 __all__ = ["Events", "Asset", "Assets", "Contract", "Collection",
            "CollectionStats", "Collections", "Bundles", "utils",
            "OpenseaAPI"]

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -92,6 +92,7 @@ class OpenseaAPI:
         auction_type=None,
         limit=None,
         occurred_before=None,
+        occurred_after=None,
         export_file_name="",
     ):
         """Fetches Events data from the API. Function arguments will be passed
@@ -113,7 +114,11 @@ class OpenseaAPI:
         """
         if occurred_before is not None and not isinstance(occurred_before,
                                                           datetime):
-            raise ValueError("occurred_before must be a datetime object")
+            raise ValueError("`occurred_before` must be a datetime object")
+
+        if occurred_after is not None and not isinstance(occurred_after,
+                                                         datetime):
+            raise ValueError("`occurred_after` must be a datetime object")
 
         query_params = {
             "asset_contract_address": asset_contract_address,
@@ -127,6 +132,9 @@ class OpenseaAPI:
         }
         if occurred_before is not None:
             query_params["occurred_before"] = occurred_before.timestamp()
+
+        if occurred_after is not None:
+            query_params["occurred_after"] = occurred_after.timestamp()
         return self._make_request("events", query_params, export_file_name)
 
     def events_backfill(self,

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -26,9 +26,8 @@ class OpenseaAPI:
         self.api_url = f"{base_url}/{version}"
         self.apikey = apikey
 
-    def _make_request(
-        self, endpoint=None, params=None, export_file_name="",
-        return_response=False):
+    def _make_request(self, endpoint=None, params=None, export_file_name="",
+                      return_response=False):
         """Makes a request to the OpenSea API and returns either a response
         object or dictionary.
 
@@ -60,8 +59,10 @@ class OpenseaAPI:
             depending on the `return_response` argument.
         """
         if endpoint is None:
-            raise ValueError("""You need to define an `endpoint` when
-                             making a request!""")
+            raise ValueError(
+                """You need to define an `endpoint` when
+                             making a request!"""
+            )
 
         headers = {"X-API-KEY": self.apikey}
         url = f"{self.api_url}/{endpoint}"
@@ -141,20 +142,21 @@ class OpenseaAPI:
             query_params["occurred_after"] = occurred_after.timestamp()
         return self._make_request("events", query_params, export_file_name)
 
-    def events_backfill(self,
-                        start,
-                        until,
-                        rate_limiting=2,
-                        asset_contract_address=None,
-                        collection_slug=None,
-                        token_id=None,
-                        account_address=None,
-                        event_type=None,
-                        only_opensea=False,
-                        auction_type=None,
-                        limit=None,
-                        collection_editor=None
-                        ):
+    def events_backfill(
+        self,
+        start,
+        until,
+        rate_limiting=2,
+        asset_contract_address=None,
+        collection_slug=None,
+        token_id=None,
+        account_address=None,
+        event_type=None,
+        only_opensea=False,
+        auction_type=None,
+        limit=None,
+        collection_editor=None,
+    ):
         """
         EXPERIMENTAL FUNCTION!
 
@@ -187,8 +189,10 @@ class OpenseaAPI:
             raise ValueError("`until` and `start` must be datetime objects")
 
         if until > start:
-            raise ValueError("""`start` must be a later point in time
-                             than `until`""")
+            raise ValueError(
+                """`start` must be a later point in time
+                             than `until`"""
+            )
 
         query_params = {
             "asset_contract_address": asset_contract_address,
@@ -200,7 +204,7 @@ class OpenseaAPI:
             "auction_type": auction_type,
             "limit": self.MAX_EVENT_ITEMS if limit is None else limit,
             "occurred_before": start,
-            "collection_editor": collection_editor
+            "collection_editor": collection_editor,
         }
 
         # make the first request to get the `next` cursor has
@@ -396,9 +400,10 @@ class OpenseaAPI:
             "offset": offset,
         }
         return self._make_request("bundles", query_params, export_file_name)
-    
-    def listings(self, asset_contract_address, token_id, limit=None,
-                 export_file_name=""):
+
+    def listings(
+        self, asset_contract_address, token_id, limit=None, export_file_name=""
+    ):
         """Fetches Listings data for an asset from the API. Function arguments
         will be passed as API query parameters, without modification.
 
@@ -412,12 +417,14 @@ class OpenseaAPI:
         Returns:
             [dict]: Listings data
         """
-        query_params = {"limit": self.MAX_LISTING_ITEMS if limit is None else limit}
+        query_params = {
+            "limit": self.MAX_LISTING_ITEMS if limit is None else limit
+        }
         endpoint = f"asset/{asset_contract_address}/{token_id}/listings"
         return self._make_request(endpoint, query_params, export_file_name)
-    
+
     def offers(self, asset_contract_address, token_id, limit=None,
-                 export_file_name=""):
+               export_file_name=""):
         """Fetches Offers data for an asset from the API. Function arguments
         will be passed as API query parameters, without modification.
 
@@ -431,6 +438,8 @@ class OpenseaAPI:
         Returns:
             [dict]: Offers data
         """
-        query_params = {"limit": self.MAX_OFFER_ITEMS if limit is None else limit}
+        query_params = {
+            "limit": self.MAX_OFFER_ITEMS if limit is None else limit
+        }
         endpoint = f"asset/{asset_contract_address}/{token_id}/offers"
         return self._make_request(endpoint, query_params, export_file_name)

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -10,6 +10,7 @@ class OpenseaAPI:
     MAX_ASSET_ITEMS = 50
     MAX_COLLECTION_ITEMS = 300
     MAX_BUNDLE_ITEMS = 50
+    MAX_LISTINGS_LIMIT = 50
 
     def __init__(self, base_url="https://api.opensea.io/api", apikey=None,
                  version="v1"):
@@ -394,3 +395,22 @@ class OpenseaAPI:
             "offset": offset,
         }
         return self._make_request("bundles", query_params, export_file_name)
+    
+    def listings(self, asset_contract_address, token_id, limit=None,
+                 export_file_name=""):
+        """Fetches Listings data for an asset from the API. Function arguments
+        will be passed as API query parameters, without modification.
+
+        OpenSea API Listings query parameters:
+        https://docs.opensea.io/reference/asset-listings
+
+        There's one extra optional argument:
+        export_file_name (str, optional): Exports the JSON data into a the
+        specified file.
+
+        Returns:
+            [dict]: Bundles data
+        """
+        query_params = {"limit": self.MAX_LISTINGS_LIMIT if limit is None else limit}
+        endpoint = f"asset/{asset_contract_address}/{token_id}/listings"
+        return self._make_request(endpoint, query_params, export_file_name)

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -150,7 +150,8 @@ class OpenseaAPI:
                         event_type=None,
                         only_opensea=False,
                         auction_type=None,
-                        limit=None
+                        limit=None,
+                        collection_editor=None
                         ):
         """
         EXPERIMENTAL FUNCTION!
@@ -196,7 +197,8 @@ class OpenseaAPI:
             "only_opensea": only_opensea,
             "auction_type": auction_type,
             "limit": self.MAX_EVENT_ITEMS if limit is None else limit,
-            "occurred_before": start
+            "occurred_before": start,
+            "collection_editor": collection_editor
         }
 
         # make the first request to get the `next` cursor has

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -93,6 +93,7 @@ class OpenseaAPI:
         limit=None,
         occurred_before=None,
         occurred_after=None,
+        collection_editor=None,
         export_file_name="",
     ):
         """Fetches Events data from the API. Function arguments will be passed
@@ -128,6 +129,7 @@ class OpenseaAPI:
             "event_type": event_type,
             "only_opensea": only_opensea,
             "auction_type": auction_type,
+            "collection_editor": collection_editor,
             "limit": self.MAX_EVENT_ITEMS if limit is None else limit,
         }
         if occurred_before is not None:

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -70,6 +70,8 @@ class OpenseaAPI:
             raise requests.exceptions.HTTPError(response.text)
         elif response.status_code == 403:
             raise ConnectionError("The server blocked access.")
+        elif response.status_code == 495:
+            raise requests.exceptions.SSLError("SSL certificate error")
         elif response.status_code == 504:
             raise TimeoutError("The server reported a gateway time-out error.")
 

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -10,7 +10,8 @@ class OpenseaAPI:
     MAX_ASSET_ITEMS = 50
     MAX_COLLECTION_ITEMS = 300
     MAX_BUNDLE_ITEMS = 50
-    MAX_LISTINGS_LIMIT = 50
+    MAX_LISTING_ITEMS = 50
+    MAX_OFFER_ITEMS = 50
 
     def __init__(self, base_url="https://api.opensea.io/api", apikey=None,
                  version="v1"):
@@ -409,8 +410,27 @@ class OpenseaAPI:
         specified file.
 
         Returns:
-            [dict]: Bundles data
+            [dict]: Listings data
         """
-        query_params = {"limit": self.MAX_LISTINGS_LIMIT if limit is None else limit}
+        query_params = {"limit": self.MAX_LISTING_ITEMS if limit is None else limit}
         endpoint = f"asset/{asset_contract_address}/{token_id}/listings"
+        return self._make_request(endpoint, query_params, export_file_name)
+    
+    def offers(self, asset_contract_address, token_id, limit=None,
+                 export_file_name=""):
+        """Fetches Offers data for an asset from the API. Function arguments
+        will be passed as API query parameters, without modification.
+
+        OpenSea API Listings query parameters:
+        https://docs.opensea.io/reference/asset-offers
+
+        There's one extra optional argument:
+        export_file_name (str, optional): Exports the JSON data into a the
+        specified file.
+
+        Returns:
+            [dict]: Offers data
+        """
+        query_params = {"limit": self.MAX_OFFER_ITEMS if limit is None else limit}
+        endpoint = f"asset/{asset_contract_address}/{token_id}/offers"
         return self._make_request(endpoint, query_params, export_file_name)

--- a/opensea/opensea_api.py
+++ b/opensea/opensea_api.py
@@ -107,7 +107,7 @@ class OpenseaAPI:
         to use datetime objects when calling this function.
 
         There's one extra optional argument:
-        export_file_name (str, optional): Exports the JSON data into a the
+        export_file_name (str, optional): Exports the JSON data into the
         specified file.
 
         Returns:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.6
+current_version = 0.1.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
         'Documentation': 'https://opensea-api.attilatoth.dev',
         'Source': 'https://github.com/zseta/python-opensea'
     },
-    version='0.1.6',
+    version='0.1.7',
     zip_safe=False,
 )


### PR DESCRIPTION
* Add support for [asset listings](https://docs.opensea.io/reference/asset-listings)
    and [asset offers](https://docs.opensea.io/reference/asset-offers) endpoints
* Add `occured_after` and `collection_editor` arguments to events endpoint
* Handle SSL error when making requests
* Docs: add example to paginate the events endpoint (using `events_backfill()`)